### PR TITLE
Update scrollTo to new interface

### DIFF
--- a/listView.js
+++ b/listView.js
@@ -11,6 +11,12 @@ import React, {
 // arbitrarily large distance to pre-render all sections for measurements
 const RENDER_AHEAD_DISTANCE = 1000000;
 
+const scrollOffset = y => ({
+  y,
+  x: 0,
+  animated: true
+});
+
 class EnhancedListView extends Component {
   static DataSource = ListView.DataSource;
   constructor(props) {
@@ -25,13 +31,13 @@ class EnhancedListView extends Component {
     if (this.listView) {
       var section = this.state.sections.find((section) => section.section === sectionId);
       if (section) {
-        this.listView.getScrollResponder().scrollTo(section.offset);
+        this.listView.getScrollResponder().scrollTo(scrollOffset(section.offset));
       }
     }
   }
   scrollToRow(sectionId, rowId) {
     if (this.listView && this.state.rowOffsets[sectionId] && this.state.rowOffsets[sectionId][rowId]) {
-      this.listView.getScrollResponder().scrollTo(this.state.rowOffsets[sectionId][rowId]);
+      this.listView.getScrollResponder().scrollTo(scrollOffset(this.state.rowOffsets[sectionId][rowId]));
     }
   }
   onSectionHeaderLayout(sectionId, event) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "react",
     "listview"
   ],
+  "peerDependencies": {
+    "react-native": "^0.20.0"
+  },
   "author": "Atticus White <contact@atticuswhite.com> (http://atticuswhite.com/)",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
In `v0.20.0` and up of RN, calling `scrollTo` with a number [has become deprecated](https://github.com/facebook/react-native/blob/v0.20.0/Libraries/Components/ScrollView/ScrollView.js#L381).

This now provides the object that the new interface requires.

Hold off on merging until #1 has been added and tagged, as this will be cutting a new release because it introduces breaking changes.
