### PR TITLE
React-native dependency fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "listview"
   ],
   "peerDependencies": {
-    "react-native": ">0.20.0"
+    "react-native": ">=0.20.0"
   },
   "author": "Atticus White <contact@atticuswhite.com> (http://atticuswhite.com/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "listview"
   ],
   "peerDependencies": {
-    "react-native": "^0.20.0"
+    "react-native": ">0.20.0"
   },
   "author": "Atticus White <contact@atticuswhite.com> (http://atticuswhite.com/)",
   "license": "MIT",


### PR DESCRIPTION
This adjusts the NPM dependency so `0.20.0` is the _minimum_ version. 
Previously, the caret forced a peer dependency of react-native `0.20.x`
