### PR TITLE
Support for React as a peer dependency

### DIFF
--- a/listView.js
+++ b/listView.js
@@ -2,8 +2,10 @@
 
 import React, {
   Component,
+  PropTypes
+} from 'react';
+import {
   ListView,
-  PropTypes,
   StyleSheet,
   View,
   Text

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "listview"
   ],
   "peerDependencies": {
-    "react-native": ">=0.20.0",
+    "react-native": ">=0.25.1",
     "react": ">=15.0.2"
   },
   "author": "Atticus White <contact@atticuswhite.com> (http://atticuswhite.com/)",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "listview"
   ],
   "peerDependencies": {
-    "react-native": ">=0.20.0"
+    "react-native": ">=0.20.0",
+    "react": ">=15.0.2"
   },
   "author": "Atticus White <contact@atticuswhite.com> (http://atticuswhite.com/)",
   "license": "MIT",


### PR DESCRIPTION
As of React Native version 0.25, you cannot require React from the npm package `react-native`; React must be provided as a peer dependency. [See relevant deprecation.](https://github.com/facebook/react-native/releases/tag/v0.25.1)

This PR makes us compatible with later versions of React Native by requiring React as a peer dependency.
