### PR TITLE
Bugfix: False-positive render error thrown by ListView

### DIFF
--- a/listView.js
+++ b/listView.js
@@ -5,6 +5,7 @@ import React, {
   ListView,
   PropTypes,
   StyleSheet,
+  ScrollView,
   View,
   Text
 } from 'react-native';
@@ -27,7 +28,8 @@ class EnhancedListView extends Component {
   static defaultProps = {
     // arbitrarily large distance to pre-render all sections for measurements
     scrollRenderAheadDistance: 1000000,
-    scrollEventThrottle: 1
+    scrollEventThrottle: 1,
+    renderScrollComponent: props => <ScrollView {...props} />
   };
   constructor(props) {
     super(props);


### PR DESCRIPTION
This is a harmless fix for a false-positive warning thrown by the underlying ListView component.

We're getting warnings thrown that we aren't providing the mandatory prop of `renderScrollComponent` to the underlying ListView. If you take a look at the internals of ListView, you'll see that it will [provide an empty ScrollView](https://github.com/facebook/react-native/blob/master/Libraries/CustomComponents/ListView/ListView.js#L283) by default, but the "renderScrollComponent" is actually [a required prop.](https://github.com/facebook/react-native/blob/master/Libraries/CustomComponents/ListView/ListView.js#L196)
