### PR TITLE
Version Bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-enhanced-listview",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An enahanced ListView component",
   "main": "listView.js",
   "scripts": {


### PR DESCRIPTION
Bumping to `1.1.1`.

I think the change in the React dependency might technically be a breaking change, but I don't think anyone uses this (since we're not on NPM). 

Core changes were really bugfixes
