### PR TITLE
Spreading ListView defaultProps

### DIFF
--- a/listView.js
+++ b/listView.js
@@ -28,10 +28,10 @@ class EnhancedListView extends Component {
     onSectionChanged: PropTypes.func
   };
   static defaultProps = {
+    ...ListView.defaultProps,
     // arbitrarily large distance to pre-render all sections for measurements
     scrollRenderAheadDistance: 1000000,
-    scrollEventThrottle: 1,
-    renderScrollComponent: props => <ScrollView {...props} />
+    scrollEventThrottle: 1
   };
   constructor(props) {
     super(props);


### PR DESCRIPTION
Recent versions of react native have made prop warnings appear for properties in this library which weren't getting provided to the underlying ListView. 

Fortunately, there are convenient default props provided by the ListView component which we can spread to avoid these warnings.
