### PR TITLE
Allow prerelease React 16.0.0 versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "peerDependencies": {
     "react-native": ">=0.25.1",
-    "react": ">=15.0.2"
+    "react": "^15.0.2 || >=16.0.0-alpha"
   },
   "author": "Atticus White <contact@atticuswhite.com> (http://atticuswhite.com/)",
   "license": "MIT",


### PR DESCRIPTION
React Native's `0.43` release enforces a React version of 16.0.0-alpha.x, which breaks the peer dependency requirement by this library.

This fix allows for prerelease React 16.0.0 versions
![image](https://cloud.githubusercontent.com/assets/6303781/24817692/910e2fc2-1bab-11e7-9d9e-e6a312cb2ef5.png)
